### PR TITLE
Added gennodejs message generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,4 +3,4 @@ project(message_generation)
 
 find_package(catkin REQUIRED)
 
-catkin_package(CATKIN_DEPENDS gencpp geneus genlisp genmsg genpy)
+catkin_package(CATKIN_DEPENDS gencpp geneus gennodejs genlisp genmsg genpy)

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
 
   <run_depend>gencpp</run_depend>
   <run_depend>geneus</run_depend>
+  <run_depend>gennodejs</run_depend>
   <run_depend>genlisp</run_depend>
   <run_depend>genmsg</run_depend>
   <run_depend>genpy</run_depend>


### PR DESCRIPTION
This adds the dependency of `gennodejs` to message generation to force the buildfarm. I am not sure this is strictly necessary, as `catkin_make` and `catkin_make install` run in a developer's workspace will both generate and deploy the messages as expected (without needing to explicitly patch `message_generation`).
However, as of last night's build, `shadow-fixed` had the `gennodejs` package in it, but did not generate any messages. Is there any way to test that this change to `message_generation` will have the desired effect of rebuilding all ROS messages for Javascript?
