### PR TITLE
CMake var to set message gen packages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,4 +3,7 @@ project(message_generation)
 
 find_package(catkin REQUIRED)
 
-catkin_package(CATKIN_DEPENDS gencpp geneus gennodejs genlisp genmsg genpy)
+set(DEFAULT_MESSAGE_GENERATION_PACKAGES gencpp;geneus;gennodejs;genlisp;genmsg;genpy)
+set(MESSAGE_GENERATION_PACKAGES "${DEFAULT_MESSAGE_GENERATION_PACKAGES}" CACHE STRING "")
+
+catkin_package(CATKIN_DEPENDS ${MESSAGE_GENERATION_PACKAGES})


### PR DESCRIPTION
Naive fix for #6.

This would meet our needs (desiring to completely remove the unneeded genXX packages from our distribution.yaml, and blacklist them as deps using rosdep). However, it would have to be documented so that users who have the genXX packages in their workspaces _already_ aren't confused that this doesn't disable them from building, only disables the dependency.